### PR TITLE
Fix includes and cleanup component destruction

### DIFF
--- a/ComponentManager.c
+++ b/ComponentManager.c
@@ -1,7 +1,7 @@
 //ComponentManager.c
 #include "ComponentManager.h"
 #include "ComponentArray.h"
-#include "Components.h" 
+#include "components.h"
 #include "TransformComponent.h" 
 
 #include <assert.h>
@@ -16,17 +16,14 @@ void ComponentManager_RegisterComponent(ComponentManager* mgr, ComponentType typ
 // Notify all component arrays that an entity has been destroyed.
 void ComponentManager_EntityDestroyed(ComponentManager* mgr, uint32_t entity)
 {
-	for (int i = 0; i < MAX_COMPONENT_TYPES; i++)
-	{
-		if (mgr->componentArrays[i]) 
-			{
-			// Call the EntityDestroyed function pointer on each registered component array
-			mgr->componentArrays[i]->EntityDestroyed(mgr->componentArrays[i], entity);
-			}
-		{
-
-		}
-	}
+    for (int i = 0; i < MAX_COMPONENT_TYPES; i++)
+    {
+        if (mgr->componentArrays[i])
+        {
+            // Call the EntityDestroyed function pointer on each registered component array
+            mgr->componentArrays[i]->EntityDestroyed(mgr->componentArrays[i], entity);
+        }
+    }
 }
 
 

--- a/ComponentManager.h
+++ b/ComponentManager.h
@@ -6,7 +6,7 @@
 #include <stdint.h>
 #include "ComponentArray.h"      // Contains the base IComponentArray struct.
 #include "ComponentTypes.h"      // Contains the ComponentType enum.
-#include "Components.h"          // Now includes definitions for Entity and Transform.
+#include "components.h"          // Contains definitions for Entity and Transform.
 
 // Define the maximum number of entities
 #define MAX_COMPONENT_TYPES 32

--- a/TransformComponent.h
+++ b/TransformComponent.h
@@ -5,7 +5,7 @@
 #define TRANSFORM_COMPONENT_H
 
 #include "ComponentArray.h"
-#include "Components.h"  // This should include the definition of Transform
+#include "components.h"  // Provides the Transform definition
 
 // Expand the macro to generate the Transform component array.
 DEFINE_COMPONENT_ARRAY(Transform)

--- a/coordinator.h
+++ b/coordinator.h
@@ -5,7 +5,7 @@
 #include "ComponentManager.h"
 #include "system_manager.h"
 #include "ComponentTypes.h"
-#include "Components.h"
+#include "components.h"
 #include "TransformComponent.h"
 #include "rigid_body_component.h"
 #include "gravity_component.h"

--- a/main.c
+++ b/main.c
@@ -11,7 +11,7 @@
 #include "gravity_component.h"
 #include "rigid_body_component.h"
 #include "physics_system.h"
-#include "Components.h"
+#include "components.h"
 #include "render3d_system.h"
 #include "module_interface.h"
 #include "debug_module.h"


### PR DESCRIPTION
## Summary
- fix case-sensitive include paths for components
- clean up ComponentManager component destruction loop

## Testing
- `gcc -fsyntax-only main.c` *(fails: SDL3/SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683f972451f083289b51314709e6f096