### PR TITLE
Add EntityManager unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# MyECSC Prototype
+
+This repository contains a simple ECS (Entity Component System) prototype.
+
+## Tests
+
+A small test program is provided in `tests/entity_manager_test.c` to verify the
+basic functionality of `EntityManager`.
+
+### Building the test
+Compile the test with GCC:
+
+```bash
+gcc -std=c11 -I. entity_manager.c tests/entity_manager_test.c -o entity_manager_test
+./entity_manager_test
+```
+
+The program will output `"Entity manager test passed"` if all assertions
+succeed.

--- a/tests/entity_manager_test.c
+++ b/tests/entity_manager_test.c
@@ -1,0 +1,30 @@
+#include "entity_manager.h"
+#include <assert.h>
+#include <stdio.h>
+
+/*
+Build instructions:
+    gcc -std=c11 -I. entity_manager.c tests/entity_manager_test.c -o entity_manager_test
+*/
+int main(void) {
+    EntityManager manager;
+    EntityManager_Init(&manager);
+    assert(manager.count == MAX_ENTITIES);
+    assert(manager.LivingEntityCount == 0);
+
+    int initialCount = manager.count;
+    int initialLiving = manager.LivingEntityCount;
+
+    Entity e = EntityManager_CreateEntity(&manager);
+
+    assert(manager.count == initialCount - 1);
+    assert(manager.LivingEntityCount == initialLiving + 1);
+
+    EntityManager_DestroyEntity(&manager, e);
+
+    assert(manager.count == initialCount);
+    assert(manager.LivingEntityCount == initialLiving);
+
+    printf("Entity manager test passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `tests/entity_manager_test.c` with asserts for create/destroy
- document build steps in new README

## Testing
- `gcc -std=c11 -I. entity_manager.c tests/entity_manager_test.c -o tests/entity_manager_test && ./tests/entity_manager_test`

------
https://chatgpt.com/codex/tasks/task_e_683f9a24ec7c8328b25694aae4a46fd6