### PR TITLE
Fix grammar in entity_manager comment

### DIFF
--- a/entity_manager.h
+++ b/entity_manager.h
@@ -17,7 +17,8 @@ typedef uint32_t Entity;
 
 typedef uint32_t Signature;
 
-// The EntityManager holds available IDs, an array of signatures (one for each entity), and a counts
+// The EntityManager holds available IDs, an array of signatures (one for each entity),
+// and a count of living entities
 typedef struct
 {
 	Entity availableEntities[MAX_ENTITIES];


### PR DESCRIPTION
## Summary
- fix grammar in the EntityManager header comment

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9a053850832892373ffacaed7767