### PR TITLE
Fix component manager comment

### DIFF
--- a/ComponentManager.h
+++ b/ComponentManager.h
@@ -8,7 +8,7 @@
 #include "ComponentTypes.h"      // Contains the ComponentType enum.
 #include "Components.h"          // Now includes definitions for Entity and Transform.
 
-// Define the maximum number of entities
+// Define the maximum number of component types.
 #define MAX_COMPONENT_TYPES 32
 
 // The ComponentManager is a collection of component arrays.


### PR DESCRIPTION
## Summary
- clarify MAX_COMPONENT_TYPES comment in `ComponentManager.h`

## Testing
- `gcc -fsyntax-only *.c` *(fails: Components.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683f9a1be1a88328aedf51d9bbab68eb