### PR TITLE
Update .gitignore for lowercase builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,9 @@ Thumbs.db
 # Ignore build directories
 x64/
 Debug/
+debug/
 Release/
+release/
 
 repomix-output.txt
 


### PR DESCRIPTION
## Summary
- ignore `debug/` and `release/` directories

## Testing
- `gcc -std=c11 -I. entity_manager.c tests/entity_manager_test.c -o entity_manager_test && ./entity_manager_test`
- `./run.sh` *(fails: SDL3 development libraries not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb7a75d0c8328ab9af21a9c72d40c