### PR TITLE
Fix build without SDL3

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,4 +1,6 @@
+#ifdef USE_SDL
 #include <SDL3/SDL.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -12,13 +14,17 @@
 #include "rigid_body_component.h"
 #include "physics_system.h"
 #include "components.h"
+#ifdef USE_SDL
 #include "render3d_system.h"
+#endif
 #include "module_interface.h"
 #include "debug_module.h"
 
 
 // Global so render3d_system.c can use it
+#ifdef USE_SDL
 SDL_Color entityColors[MAX_ENTITIES];
+#endif
 
 int main(void) {
     // --- Initialize ECS Managers ---
@@ -58,9 +64,11 @@ int main(void) {
     PhysicsSystem_Init(physicsSystem, componentManager);
     SystemManager_AddSystem(systemManager, (ECS_System*)physicsSystem);
 
+#ifdef USE_SDL
     Render3DSystem render3dSystem;
     Render3DSystem_Init(&render3dSystem, componentManager);
     SystemManager_AddSystem(systemManager, (ECS_System*)&render3dSystem);
+#endif
 
     // Initialize the coordinator
     Coordinator coordinator;
@@ -104,16 +112,19 @@ int main(void) {
         };
 
         // Assign random color
+#ifdef USE_SDL
         entityColors[entity].r = rand() % 256;
         entityColors[entity].g = rand() % 256;
         entityColors[entity].b = rand() % 256;
         entityColors[entity].a = 255;
+#endif
 
         Coordinator_AddGravity(&coordinator, entity, g);
         Coordinator_AddRigidBody(&coordinator, entity, rb);
         Coordinator_AddTransform(&coordinator, entity, t);
     }
 
+#ifdef USE_SDL
     // ---- Initialize SDL3 ----
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
         fprintf(stderr, "SDL_Init Error: %s\n", SDL_GetError());
@@ -151,7 +162,6 @@ int main(void) {
         // Update physics
         PhysicsSystem_Update(physicsSystem, dt);
 
-
         // Clear screen
         SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
         SDL_RenderClear(renderer);
@@ -176,6 +186,20 @@ int main(void) {
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(window);
     SDL_Quit();
+#else
+    // Headless mode: run a short simulation and print the position of the first entity
+    float dt = 0.016f;
+    for (int i = 0; i < 100; i++) {
+        PhysicsSystem_Update(physicsSystem, dt);
+        if (gDebugSystem) {
+            DebugSystem_Run(gDebugSystem, dt);
+        }
+        Transform* t = TransformComponentArray_GetData(transformArray, 0);
+        if (t) {
+            printf("Step %d: pos=(%.2f, %.2f, %.2f)\n", i, t->position.x, t->position.y, t->position.z);
+        }
+    }
+#endif
 
     free(physicsSystem);
     free(rigidBodyArray);

--- a/render3d_system.c
+++ b/render3d_system.c
@@ -1,4 +1,5 @@
 #include "render3d_system.h"
+#ifdef USE_SDL
 #include "TransformComponent.h"
 #include "coordinator.h"
 #include "components.h"
@@ -133,7 +134,7 @@ static void renderSolidCube(SDL_Renderer* renderer,
         vertices[i].position.x = projX + screenWidth / 2.0f;
         vertices[i].position.y = -projY + screenHeight / 2.0f;
 
-        // Convert SDL_Color (0–255) to SDL_FColor (0–1).
+        // Convert SDL_Color (0-255) to SDL_FColor (0-1).
         vertices[i].color.r = color.r / 255.0f;
         vertices[i].color.g = color.g / 255.0f;
         vertices[i].color.b = color.b / 255.0f;
@@ -193,3 +194,4 @@ void Render3DSystem_Update(Render3DSystem* r3dSys, float dt,
         }
     }
 }
+#endif

--- a/render3d_system.h
+++ b/render3d_system.h
@@ -5,7 +5,9 @@
 #include "entity_manager.h"
 #include "ComponentManager.h"
 #include "ComponentTypes.h"
-#include "SDL3/SDL.h"
+#ifdef USE_SDL
+#include <SDL3/SDL.h>
+#endif
 #include <math.h>
 
 // Render3DSystem structure that holds a base ECS_System and a pointer to the ComponentManager.
@@ -18,8 +20,10 @@ typedef struct {
 // Initialize the Render3DSystem with the ComponentManager.
 void Render3DSystem_Init(Render3DSystem* r3dSys, ComponentManager* cm);
 
+#ifdef USE_SDL
 // Update the Render3DSystem: for each entity, render a 3D wireframe cube.
 // The renderer, dt, and screen parameters are passed in.
 void Render3DSystem_Update(Render3DSystem* r3dSys, float dt, SDL_Renderer* renderer, int screenWidth, int screenHeight);
+#endif
 
 #endif // RENDER3D_SYSTEM_H

--- a/run.sh
+++ b/run.sh
@@ -6,19 +6,29 @@ set -e
 if command -v sdl3-config >/dev/null 2>&1; then
     SDL_CFLAGS="$(sdl3-config --cflags)"
     SDL_LIBS="$(sdl3-config --libs)"
+    USE_SDL=1
 elif command -v pkg-config >/dev/null 2>&1 && pkg-config --exists sdl3; then
     SDL_CFLAGS="$(pkg-config --cflags sdl3)"
     SDL_LIBS="$(pkg-config --libs sdl3)"
+    USE_SDL=1
 else
-    echo "SDL3 development libraries not found. Please install SDL3." >&2
-    exit 1
+    echo "SDL3 development libraries not found. Building in headless mode." >&2
+    USE_SDL=0
+    SDL_CFLAGS=""
+    SDL_LIBS=""
 fi
 
 # Source files needed to build the demo
-SRCS="main.c coordinator.c entity_manager.c ComponentManager.c physics_system.c render3d_system.c debug_module.c module.c"
+SRCS="main.c coordinator.c entity_manager.c ComponentManager.c physics_system.c debug_module.c module.c"
+if [ "$USE_SDL" -eq 1 ]; then
+    SRCS="$SRCS render3d_system.c"
+    CFLAGS_EXTRA="-DUSE_SDL"
+else
+    CFLAGS_EXTRA=""
+fi
 
 # Build the executable
-gcc -std=c11 $SDL_CFLAGS -I. $SRCS -o MyECSC_Prototype $SDL_LIBS
+gcc -std=c11 $CFLAGS_EXTRA $SDL_CFLAGS -I. $SRCS -o MyECSC_Prototype $SDL_LIBS
 
 # Run the program
 ./MyECSC_Prototype


### PR DESCRIPTION
## Summary
- allow building and running when SDL3 isn't installed
- wrap render system and rendering code with `USE_SDL`
- add a simple headless mode demonstration in `main.c`
- update `run.sh` to detect SDL3 and compile accordingly

## Testing
- `gcc -std=c11 -I. entity_manager.c tests/entity_manager_test.c -o entity_manager_test && ./entity_manager_test`
- `./run.sh >/tmp/run.log && tail -n 5 /tmp/run.log`

------
https://chatgpt.com/codex/tasks/task_e_686f3ca78ba4832886d7fbda4578a769