### PR TITLE
Resolve Windows-only module loader

### DIFF
--- a/src/module_loader.c
+++ b/src/module_loader.c
@@ -1,10 +1,15 @@
-#include <windows.h>
 #include <stdio.h>
 #include "coordinator.h"
 #include "module_interface.h"
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
 
-// Load a module (DLL) and call its register_module function.
+// Load a module and call its register_module function.
 void load_module(const char* modulePath, Coordinator* coordinator) {
+#ifdef _WIN32
     HMODULE handle = LoadLibraryA(modulePath);
     if (!handle) {
         fprintf(stderr, "Error loading module %s\n", modulePath);
@@ -17,4 +22,22 @@ void load_module(const char* modulePath, Coordinator* coordinator) {
         return;
     }
     register_module(coordinator);
+    FreeLibrary(handle);
+#else
+    dlerror(); // Clear any existing error
+    void* handle = dlopen(modulePath, RTLD_NOW);
+    if (!handle) {
+        fprintf(stderr, "Error loading module %s: %s\n", modulePath, dlerror());
+        return;
+    }
+    ModuleRegisterFunc register_module = (ModuleRegisterFunc)dlsym(handle, "register_module");
+    const char* err = dlerror();
+    if (err) {
+        fprintf(stderr, "Error finding register_module in %s: %s\n", modulePath, err);
+        dlclose(handle);
+        return;
+    }
+    register_module(coordinator);
+    dlclose(handle);
+#endif
 }


### PR DESCRIPTION
## Summary
- make the module loader portable by supporting Linux with dlopen

## Testing
- `./run.sh`
- `gcc -std=c11 -Iinclude src/entity_manager.c tests/entity_manager_test.c -o entity_manager_test && ./entity_manager_test`


------
https://chatgpt.com/codex/tasks/task_e_686f498f8b248328985fc405313e173a